### PR TITLE
In the tracker, process dimension values (via Dimension class method) be...

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -240,4 +240,36 @@ abstract class Dimension
         $parts = explode('.', $id);
         return reset($parts);
     }
+
+    /**
+     * Prepare a dimension value found in a tracker request for persistence in MySQL. Dimensions
+     * should use this method to, for example, truncate values that are too long for their MySQL
+     * database columns.
+     *
+     * Note: This method may be removed if/when a proper data access layer is added to Piwik.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function prepareDimensionValueForPersistence($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Helper function for the tracker. Calls prepareDimensionValueForPersistence() on dimensions that
+     * are present in $dimensionValues.
+     * @param Dimension[] $dimensions
+     * @param array $dimensionValues
+     * @ignore
+     */
+    public static function prepareDimensionValuesForPersistence($dimensions, &$dimensionValues)
+    {
+        foreach ($dimensions as $dimension) {
+            $dimensionName = $dimension->getColumnName();
+            if (isset($dimensionValues[$dimensionName])) {
+                $dimensionValues[$dimensionName] = $dimension->prepareDimensionValueForPersistence($dimensionValues[$dimensionName]);
+            }
+        }
+    }
 }

--- a/core/Plugin/Dimension/VisitDimension.php
+++ b/core/Plugin/Dimension/VisitDimension.php
@@ -352,5 +352,4 @@ abstract class VisitDimension extends Dimension
 
         return $instances;
     }
-
 }

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -10,6 +10,7 @@
 namespace Piwik\Tracker;
 
 use Exception;
+use Piwik\Columns\Dimension;
 use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Plugin\Dimension\ActionDimension;
@@ -377,6 +378,8 @@ abstract class Action
         }
 
         $visitAction = array_merge($visitAction, $customVariables);
+
+        Dimension::prepareDimensionValuesForPersistence($dimensions, $visitAction);
 
         $this->idLinkVisitAction = $this->getModel()->createAction($visitAction);
 

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -9,6 +9,7 @@
 namespace Piwik\Tracker;
 
 use Exception;
+use Piwik\Columns\Dimension;
 use Piwik\Common;
 use Piwik\Date;
 use Piwik\Piwik;
@@ -298,6 +299,8 @@ class GoalManager
             Common::printDebug("There is an existing cart for this visit");
         }
 
+        $conversionDimensions = ConversionDimension::getAllDimensions();
+
         if ($this->isGoalAnOrder) {
             $debugMessage = 'The conversion is an Ecommerce order';
 
@@ -305,7 +308,6 @@ class GoalManager
             $conversion['idgoal']  = self::IDGOAL_ORDER;
             $conversion['buster']  = Common::hashStringToInt($this->orderId);
 
-            $conversionDimensions = ConversionDimension::getAllDimensions();
             $conversion = $this->triggerHookOnDimensions($conversionDimensions, 'onEcommerceOrderConversion', $visitor, $action, $conversion);
         } // If Cart update, select current items in the previous Cart
         else {
@@ -314,7 +316,6 @@ class GoalManager
             $conversion['buster'] = 0;
             $conversion['idgoal'] = self::IDGOAL_CART;
 
-            $conversionDimensions = ConversionDimension::getAllDimensions();
             $conversion = $this->triggerHookOnDimensions($conversionDimensions, 'onEcommerceCartUpdateConversion', $visitor, $action, $conversion);
         }
 
@@ -333,6 +334,8 @@ class GoalManager
         }
 
         $conversion['items'] = $itemsCount;
+
+        Dimension::prepareDimensionValuesForPersistence($conversionDimensions, $conversion);
 
         if ($this->isThereExistingCartInVisit) {
             $recorded = $this->getModel()->updateConversion($visitInformation['idvisit'], self::IDGOAL_CART, $conversion);

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tracker;
 
+use Piwik\Columns\Dimension;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\DataAccess\ArchiveInvalidator;
@@ -437,6 +438,8 @@ class Visit implements VisitInterface
      */
     protected function updateExistingVisit($valuesToUpdate)
     {
+        $this->prepareDimensionValuesForPersistence($valuesToUpdate);
+
         $idSite  = $this->request->getIdSite();
         $idVisit = (int) $this->visitorInfo['idvisit'];
 
@@ -603,6 +606,8 @@ class Visit implements VisitInterface
 
     protected function insertNewVisit($visit)
     {
+        $this->prepareDimensionValuesForPersistence($visit);
+
         return $this->getModel()->createVisit($visit);
     }
 
@@ -649,5 +654,11 @@ class Visit implements VisitInterface
             $invalidReport = new ArchiveInvalidator();
             $invalidReport->rememberToInvalidateArchivedReportsLater($idSite, $date);
         }
+    }
+
+    private function prepareDimensionValuesForPersistence(&$dimensionValues)
+    {
+        $dimensions = $this->getAllVisitDimensions();
+        Dimension::prepareDimensionValuesForPersistence($dimensions, $dimensionValues);
     }
 }

--- a/plugins/Referrers/Columns/Keyword.php
+++ b/plugins/Referrers/Columns/Keyword.php
@@ -42,11 +42,6 @@ class Keyword extends Base
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
         $information = $this->getReferrerInformationFromRequest($request);
-
-        if (!empty($information['referer_keyword'])) {
-            return substr($information['referer_keyword'], 0, 255);
-        }
-
         return $information['referer_keyword'];
     }
 
@@ -59,5 +54,10 @@ class Keyword extends Base
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $this->getValueForRecordGoal($request, $visitor);
+    }
+
+    public function prepareDimensionValueForPersistence($value)
+    {
+        return substr($value, 0, 255);
     }
 }

--- a/plugins/Referrers/Columns/ReferrerName.php
+++ b/plugins/Referrers/Columns/ReferrerName.php
@@ -36,12 +36,6 @@ class ReferrerName extends Base
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
         $information = $this->getReferrerInformationFromRequest($request);
-
-        if (!empty($information['referer_name'])) {
-
-            return substr($information['referer_name'], 0, 70);
-        }
-
         return $information['referer_name'];
     }
 
@@ -54,5 +48,10 @@ class ReferrerName extends Base
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $this->getValueForRecordGoal($request, $visitor);
+    }
+
+    public function prepareDimensionValueForPersistence($value)
+    {
+        return substr($value, 0, 70);
     }
 }


### PR DESCRIPTION
...fore inserting/updating in MySQL instead of directly after computing dimension values. This way, if plugins modify dimension values, they will still be processed correctly (ie, truncated so MySQL doesn't throw) w/o the plugins having to know about the processing logic.